### PR TITLE
Remove asterisks from query string

### DIFF
--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -131,7 +131,11 @@ class ElasticsearchEngine extends Engine
             'body' => [
                 'query' => [
                     'bool' => [
-                        'must' => [['query_string' => [ 'query' => "*{$builder->query}*"]]]
+                        'must' => [
+                            [
+                                'query_string' => [ 'query' => $builder->query ]
+                            ]
+                        ]
                     ]
                 ]
             ]


### PR DESCRIPTION
I have removed wildcards from query_string because it breaks relevancy of the search. If we use wildcards it set constant_score as 1.0
Here are several articles about that:
https://www.elastic.co/guide/en/elasticsearch/reference/5.5/query-dsl-bool-query.html#_scoring_with_literal_bool_filter_literal
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-term-rewrite.html
https://discuss.elastic.co/t/wildcard-query-returning-results-in-random-order/57124
https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-query-string-query.html#_wildcards